### PR TITLE
Add pre-install backups, dry-run support, and deferred force-linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ relative to your home directory. Installation stops if a backup cannot be
 created. Forced replacement is enabled only by the installers, after this
 backup succeeds.
 
+For standalone configs ending in `-sudo`, the installer explicitly preserves
+the caller's `HOME` for Dotbot so privileged linking targets the same paths that
+were backed up.
+
 Preview the destinations that would be backed up and the selected profile or
 configs without modifying the filesystem or updating submodules:
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,27 @@ $ ./install-standalone <configs...>
 ```
 See [meta/configs/](./meta/configs) for available configurations
 
+### Existing files and dry runs
+
+Installation replaces configured destinations with symlinks. Before relinking, any
+existing file, directory, or symlink at a configured destination is copied to
+`~/.dotfiles-backups/<UTC timestamp>-<process ID>/`, preserving its path
+relative to your home directory. Installation stops if a backup cannot be
+created. Forced replacement is enabled only by the installers, after this
+backup succeeds.
+
+Preview the destinations that would be backed up and the selected profile or
+configs without modifying the filesystem or updating submodules:
+
+```bash
+./install-profile --dry-run linux
+./install-standalone --dry-run bash zsh
+```
+
+`--check` is accepted as an alias for `--dry-run`. Restore a backup by copying the
+desired file from its timestamped directory back to the corresponding path in
+your home directory after removing the generated symlink.
+
 ## Contents
 
 ### Profiles

--- a/install-profile
+++ b/install-profile
@@ -1,6 +1,9 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 BASE_CONFIG="base"
+FORCE_CONFIG="force-links-after-backup"
 CONFIG_SUFFIX=".yaml"
 
 META_DIR="meta"
@@ -12,15 +15,45 @@ DOTBOT_BIN="bin/dotbot"
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+dry_run=false
+if [[ ${1:-} == "--dry-run" || ${1:-} == "--check" ]]; then
+    dry_run=true
+    shift
+fi
+
+if (( $# == 0 )); then
+    echo "Usage: $0 [--dry-run|--check] <profile>" >&2
+    exit 2
+fi
+
+profile_file="${BASE_DIR}/${META_DIR}/${PROFILES_DIR}/$1"
+[[ -f $profile_file ]] || { echo "Unknown profile: $1" >&2; exit 1; }
+
+mapfile -t lines < "$profile_file"
+config_files=()
+for config in "${lines[@]}"; do
+    profileConfigName=${config//$'\t\r\n'/}
+    [[ -n $profileConfigName ]] || continue
+    config_files+=("${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${profileConfigName}${CONFIG_SUFFIX}")
+done
+
+if $dry_run; then
+    "${BASE_DIR}/scripts/backup-dotfiles" --dry-run "${config_files[@]}"
+    printf 'Would install profile %s with configs: %s\n' "$1" "${lines[*]}"
+    exit 0
+fi
+
 git submodule update --init --recursive --remote
 
-IFS=$'\n' read -d '' -r -a lines < "${BASE_DIR}/${META_DIR}/${PROFILES_DIR}/$1"
-for config in ${lines[@]}; do
+"${BASE_DIR}/scripts/backup-dotfiles" "${config_files[@]}"
+
+for config in "${lines[@]}"; do
     echo -e "\nConfigure $config"
     configFile="$(mktemp)"
-    profileConfigName=${config//[$'\t\r\n']} && CLEANED=${CLEANED%%*( )}
-    cat "${BASE_DIR}/${META_DIR}/${BASE_CONFIG}${CONFIG_SUFFIX}" >> $configFile
-    cat "${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${profileConfigName}${CONFIG_SUFFIX}" >> $configFile
+    profileConfigName=${config//$'\t\r\n'/}
+    cat "${BASE_DIR}/${META_DIR}/${BASE_CONFIG}${CONFIG_SUFFIX}" >> "$configFile"
+    cat "${BASE_DIR}/${META_DIR}/${FORCE_CONFIG}${CONFIG_SUFFIX}" >> "$configFile"
+    cat "${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${profileConfigName}${CONFIG_SUFFIX}" >> "$configFile"
     cmd=("${BASE_DIR}/${META_DIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASE_DIR}" -c "$configFile")
     "${cmd[@]}"
     rm -f "$configFile"

--- a/install-standalone
+++ b/install-standalone
@@ -3,6 +3,7 @@
 set -e
 
 BASE_CONFIG="base"
+FORCE_CONFIG="force-links-after-backup"
 CONFIG_SUFFIX=".yaml"
 
 META_DIR="meta"
@@ -14,14 +15,40 @@ DOTBOT_BIN="bin/dotbot"
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
+dry_run=false
+if [[ ${1:-} == "--dry-run" || ${1:-} == "--check" ]]; then
+    dry_run=true
+    shift
+fi
+
+if (( $# == 0 )); then
+    echo "Usage: $0 [--dry-run|--check] <config>..." >&2
+    exit 2
+fi
+
+config_files=()
+for config in "$@"; do
+    suffix="-sudo"
+    config_files+=("${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${config%"$suffix"}${CONFIG_SUFFIX}")
+done
+
+if $dry_run; then
+    "${BASE_DIR}/scripts/backup-dotfiles" --dry-run "${config_files[@]}"
+    printf 'Would install configs: %s\n' "$*"
+    exit 0
+fi
 
 cd "${BASE_DIR}"
 git submodule update --init --recursive --remote
 
-for config in ${@}; do
+"${BASE_DIR}/scripts/backup-dotfiles" "${config_files[@]}"
+
+for config in "$@"; do
     configFile="$(mktemp)"
     suffix="-sudo"
-    echo -e "$(<"${BASE_DIR}/${META_DIR}/${BASE_CONFIG}${CONFIG_SUFFIX}")\n$(<"${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${config%"$suffix"}${CONFIG_SUFFIX}")" > "$configFile"
+    cat "${BASE_DIR}/${META_DIR}/${BASE_CONFIG}${CONFIG_SUFFIX}" > "$configFile"
+    cat "${BASE_DIR}/${META_DIR}/${FORCE_CONFIG}${CONFIG_SUFFIX}" >> "$configFile"
+    cat "${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${config%"$suffix"}${CONFIG_SUFFIX}" >> "$configFile"
 
     cmd=("${BASE_DIR}/${META_DIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASE_DIR}" -c "$configFile")
 

--- a/install-standalone
+++ b/install-standalone
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-set -e
+set -euo pipefail
 
 BASE_CONFIG="base"
 FORCE_CONFIG="force-links-after-backup"
@@ -14,6 +14,7 @@ DOTBOT_DIR="dotbot"
 DOTBOT_BIN="bin/dotbot"
 
 BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CALLER_HOME=$HOME
 
 dry_run=false
 if [[ ${1:-} == "--dry-run" || ${1:-} == "--check" ]]; then
@@ -52,8 +53,11 @@ for config in "$@"; do
 
     cmd=("${BASE_DIR}/${META_DIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASE_DIR}" -c "$configFile")
 
-    if [[ $config == *"sudo"* ]]; then
-        cmd=(sudo "${cmd[@]}")
+    if [[ $config == *-sudo ]]; then
+        # Dotbot must resolve $HOME exactly as the backup step did. Passing the
+        # caller's value explicitly prevents sudo's HOME reset from changing
+        # the force-link destinations after they have been backed up.
+        cmd=(sudo HOME="$CALLER_HOME" "${cmd[@]}")
     fi
 
     "${cmd[@]}"

--- a/meta/base.yaml
+++ b/meta/base.yaml
@@ -2,16 +2,9 @@
     link:
       relink: true
       create: true
-      force: true
     shell:
       stdout: true
       stderr: true
 
 - create:
     - $HOME/.config
-
-- clean:
-    $HOME:
-        force: true
-    $HOME/.config:
-        recursive: true

--- a/meta/force-links-after-backup.yaml
+++ b/meta/force-links-after-backup.yaml
@@ -1,0 +1,3 @@
+- defaults:
+    link:
+      force: true

--- a/scripts/backup-dotfiles
+++ b/scripts/backup-dotfiles
@@ -56,9 +56,7 @@ backup_destination() {
 for config in "$@"; do
     [[ -f $config ]] || { echo "Config not found: $config" >&2; exit 1; }
 
-    while IFS= read -r destination; do
-        backup_destination "$(expand_destination "$destination")"
-    done < <(
+    mapfile -t destinations < <(
         awk '
             /^- link:[[:space:]]*$/ { in_link = 1; next }
             /^- / { in_link = 0 }
@@ -70,4 +68,13 @@ for config in "$@"; do
             }
         ' "$config"
     )
+
+    if [[ -s $config && ${#destinations[@]} -eq 0 ]]; then
+        echo "No link destinations could be parsed from non-empty config: $config" >&2
+        exit 1
+    fi
+
+    for destination in "${destinations[@]}"; do
+        backup_destination "$(expand_destination "$destination")"
+    done
 done

--- a/scripts/backup-dotfiles
+++ b/scripts/backup-dotfiles
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+usage() {
+    echo "Usage: $0 [--dry-run] <config.yaml>..." >&2
+}
+
+dry_run=false
+if [[ ${1:-} == "--dry-run" ]]; then
+    dry_run=true
+    shift
+fi
+
+if (( $# == 0 )); then
+    usage
+    exit 2
+fi
+
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)-$$"
+backup_root="${DOTFILES_BACKUP_DIR:-${HOME}/.dotfiles-backups}/${timestamp}"
+declare -A seen=()
+
+expand_destination() {
+    local destination=$1
+
+    destination=${destination/#\~\//$HOME/}
+    destination=${destination/#\$HOME\//$HOME/}
+    printf '%s\n' "$destination"
+}
+
+backup_destination() {
+    local destination=$1 relative backup
+
+    [[ -e $destination || -L $destination ]] || return 0
+    [[ ${seen[$destination]+yes} ]] && return 0
+    seen[$destination]=1
+
+    if [[ $destination == "$HOME"/* ]]; then
+        relative=${destination#"$HOME"/}
+    else
+        relative="external/${destination#/}"
+    fi
+    backup="${backup_root}/${relative}"
+
+    if $dry_run; then
+        printf 'Would back up %s to %s\n' "$destination" "$backup"
+        return 0
+    fi
+
+    mkdir -p "$(dirname "$backup")"
+    cp -a -- "$destination" "$backup"
+    printf 'Backed up %s to %s\n' "$destination" "$backup"
+}
+
+for config in "$@"; do
+    [[ -f $config ]] || { echo "Config not found: $config" >&2; exit 1; }
+
+    while IFS= read -r destination; do
+        backup_destination "$(expand_destination "$destination")"
+    done < <(
+        awk '
+            /^- link:[[:space:]]*$/ { in_link = 1; next }
+            /^- / { in_link = 0 }
+            in_link && /^    [^ #][^:]*:[[:space:]]*/ {
+                line = $0
+                sub(/^    /, "", line)
+                sub(/:[[:space:]]*.*$/, "", line)
+                print line
+            }
+        ' "$config"
+    )
+done

--- a/tests/backup-dotfiles.sh
+++ b/tests/backup-dotfiles.sh
@@ -40,6 +40,14 @@ if DOTFILES_BACKUP_DIR="$failed_backup_root" \
 fi
 [[ $(cat "$HOME/.bashrc") == "original bashrc" ]]
 
+cat > "${TEST_DIR}/unrecognized.yaml" <<'EOF'
+- link: { ~/.bashrc: common/bash/.bashrc }
+EOF
+if "${ROOT}/scripts/backup-dotfiles" "${TEST_DIR}/unrecognized.yaml" >/dev/null 2>&1; then
+    echo "expected an unrecognized non-empty config to fail closed" >&2
+    exit 1
+fi
+
 profile_output="$(HOME="$HOME" "${ROOT}/install-profile" --dry-run linux)"
 [[ $profile_output == *"Would install profile linux"* ]]
 
@@ -48,5 +56,53 @@ standalone_output="$(HOME="$HOME" "${ROOT}/install-standalone" --check bash)"
 
 ! grep -q 'force:' "${ROOT}/meta/base.yaml"
 grep -q 'force: true' "${ROOT}/meta/force-links-after-backup.yaml"
+
+sudo_test_root="${TEST_DIR}/sudo-install"
+sudo_caller_home="${TEST_DIR}/sudo-caller-home"
+sudo_reset_home="${TEST_DIR}/sudo-reset-home"
+mkdir -p "$sudo_test_root/scripts" "$sudo_test_root/meta/configs" \
+    "$sudo_test_root/meta/dotbot/bin" "$sudo_test_root/fake-bin" \
+    "$sudo_caller_home" "$sudo_reset_home"
+cp "${ROOT}/install-standalone" "$sudo_test_root/"
+cp "${ROOT}/scripts/backup-dotfiles" "$sudo_test_root/scripts/"
+cp "${ROOT}/meta/base.yaml" "${ROOT}/meta/force-links-after-backup.yaml" \
+    "$sudo_test_root/meta/"
+cat > "$sudo_test_root/meta/configs/sudo-home.yaml" <<'EOF'
+- link:
+    $HOME/.sudo-home-test: source
+EOF
+printf 'caller data\n' > "$sudo_caller_home/.sudo-home-test"
+
+cat > "$sudo_test_root/fake-bin/git" <<'EOF'
+#!/usr/bin/env bash
+exit 0
+EOF
+cat > "$sudo_test_root/fake-bin/sudo" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+export HOME=$SUDO_RESET_HOME
+if [[ ${1:-} == HOME=* ]]; then
+    export "${1}"
+    shift
+fi
+exec "$@"
+EOF
+cat > "$sudo_test_root/meta/dotbot/bin/dotbot" <<'EOF'
+#!/usr/bin/env bash
+printf '%s\n' "$HOME" > "$DOTBOT_HOME_RESULT"
+EOF
+chmod +x "$sudo_test_root/fake-bin/git" "$sudo_test_root/fake-bin/sudo" \
+    "$sudo_test_root/meta/dotbot/bin/dotbot"
+
+sudo_backup_dir="${TEST_DIR}/sudo-backups"
+HOME="$sudo_caller_home" DOTFILES_BACKUP_DIR="$sudo_backup_dir" \
+    SUDO_RESET_HOME="$sudo_reset_home" \
+    DOTBOT_HOME_RESULT="${TEST_DIR}/dotbot-home" \
+    PATH="$sudo_test_root/fake-bin:$PATH" \
+    "$sudo_test_root/install-standalone" sudo-home-sudo
+sudo_backup_run="$(find "$sudo_backup_dir" -mindepth 1 -maxdepth 1 -type d)"
+[[ $(cat "$sudo_backup_run/.sudo-home-test") == "caller data" ]]
+[[ $(cat "${TEST_DIR}/dotbot-home") == "$sudo_caller_home" ]]
+[[ ! -e "$sudo_reset_home/.sudo-home-test" ]]
 
 echo "backup-dotfiles tests passed"

--- a/tests/backup-dotfiles.sh
+++ b/tests/backup-dotfiles.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+export HOME="${TEST_DIR}/home"
+export DOTFILES_BACKUP_DIR="${TEST_DIR}/backups"
+mkdir -p "$HOME/.config/example"
+printf 'original bashrc\n' > "$HOME/.bashrc"
+printf 'original settings\n' > "$HOME/.config/example/settings.json"
+
+cat > "${TEST_DIR}/config.yaml" <<'EOF'
+- link:
+    ~/.bashrc: common/bash/.bashrc
+    $HOME/.config/example/settings.json:
+        path: common/example/settings.json
+EOF
+
+dry_run_output="$("${ROOT}/scripts/backup-dotfiles" --dry-run "${TEST_DIR}/config.yaml")"
+[[ $dry_run_output == *"Would back up $HOME/.bashrc"* ]]
+[[ $dry_run_output == *"Would back up $HOME/.config/example/settings.json"* ]]
+[[ ! -e $DOTFILES_BACKUP_DIR ]]
+
+"${ROOT}/scripts/backup-dotfiles" "${TEST_DIR}/config.yaml"
+backup_run="$(find "$DOTFILES_BACKUP_DIR" -mindepth 1 -maxdepth 1 -type d)"
+[[ $(cat "$backup_run/.bashrc") == "original bashrc" ]]
+[[ $(cat "$backup_run/.config/example/settings.json") == "original settings" ]]
+[[ $(cat "$HOME/.bashrc") == "original bashrc" ]]
+[[ $(cat "$HOME/.config/example/settings.json") == "original settings" ]]
+
+failed_backup_root="${TEST_DIR}/not-a-directory"
+printf 'occupied\n' > "$failed_backup_root"
+if DOTFILES_BACKUP_DIR="$failed_backup_root" \
+    "${ROOT}/scripts/backup-dotfiles" "${TEST_DIR}/config.yaml" >/dev/null 2>&1; then
+    echo "expected an unwritable backup destination to fail" >&2
+    exit 1
+fi
+[[ $(cat "$HOME/.bashrc") == "original bashrc" ]]
+
+profile_output="$(HOME="$HOME" "${ROOT}/install-profile" --dry-run linux)"
+[[ $profile_output == *"Would install profile linux"* ]]
+
+standalone_output="$(HOME="$HOME" "${ROOT}/install-standalone" --check bash)"
+[[ $standalone_output == *"Would install configs: bash"* ]]
+
+! grep -q 'force:' "${ROOT}/meta/base.yaml"
+grep -q 'force: true' "${ROOT}/meta/force-links-after-backup.yaml"
+
+echo "backup-dotfiles tests passed"


### PR DESCRIPTION
### Motivation

- Ensure existing files are safely preserved before installers replace destinations with symlinks. 
- Provide a non-destructive preview mode so users can see what would be backed up and installed. 
- Avoid using `force: true` in the base config so destructive link forcing only happens after backups succeed.

### Description

- Add `scripts/backup-dotfiles` which scans config YAMLs for `- link:` destinations and copies any existing file/dir/symlink to `~/.dotfiles-backups/<UTC timestamp>-<pid>/`, with a `--dry-run` mode. 
- Update `install-profile` and `install-standalone` to accept `--dry-run` (and `--check` alias), run the backup script before performing installs, and include a `force-links-after-backup.yaml` snippet (concatenated into generated dotbot configs) so `force: true` is only applied after successful backups. 
- Move `force: true` out of `meta/base.yaml` into new `meta/force-links-after-backup.yaml` and remove the previous aggressive clean directives. 
- Document backup, dry-run, and restore behavior in `README.md`. 
- Add an executable test script `tests/backup-dotfiles.sh` to validate backup behavior and installers' dry-run outputs.

### Testing

- Ran `tests/backup-dotfiles.sh` which exercises `scripts/backup-dotfiles --dry-run`, a real backup run, failure on unwritable backup root, and verifies `install-profile --dry-run` and `install-standalone --check`; the test script completed and reported success.
