### PR TITLE
fix: pin and verify remotely downloaded installers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,43 +1,48 @@
 # Default target
 .DEFAULT_GOAL := help
 
+# Pinned upstream revisions. See README.md before updating these values.
+OH_MY_POSH_VERSION := 29.34.0
+OH_MY_POSH_LINUX_SHA256 := 90f33e71f181e959f1511d03f05ee0843c5eab4d7799e2d479a13c3fdd5b7c44
+OH_MY_ZSH_COMMIT := 59a9740721b734835812121322d6fe4827b0853a
+ZSH_SYNTAX_HIGHLIGHTING_COMMIT := 1d85c692615a25fe2293bdd44b34c217d5d2bf04
+ZSH_AUTOSUGGESTIONS_COMMIT := 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5
+
 # PHONY
 .PHONY: windows linux
 
-# Targets
-
 help :
-	@echo "win 	: Bootstrap and install dotfiles for Windows"
-	@echo "lin	: Bootstrap and install dotfiles for Linux"
-
-# Windows
+	@echo "win \t: Bootstrap and install dotfiles for Windows"
+	@echo "lin\t: Bootstrap and install dotfiles for Linux"
 
 bootstrap-windows:
 	@echo "-> Installing Powerline font Source Code Pro - https://github.com/powerline/fonts"
 	powershell common/fonts/prerequisite.ps1
 	powershell common/fonts/install.ps1
-	@echo "-> Installing Scoop - https://github.com/lukesampson/scoop"
-	powershell 'iwr -useb get.scoop.sh | iex'
-	@echo "-> Installing oh-my-posh - https://ohmyposh.dev"
-	powershell "scoop install 'https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/oh-my-posh.json'"
+	@echo "-> Installing pinned oh-my-posh"
+	powershell -NoProfile -ExecutionPolicy Bypass -File scripts/install-windows-tools.ps1
 
 windows: bootstrap-windows
 	./install-profile windows
 
-# Linux
-
 bootstrap-linux:
 	@echo "Install Powerline font - Source Code Pro - https://github.com/powerline/fonts"
 	sh common/fonts/install.sh
-	@echo "-> Installing oh-my-posh - https://ohmyposh.dev"
-	sudo wget https://github.com/JanDeDobbeleer/oh-my-posh/releases/latest/download/posh-linux-amd64 -O /usr/local/bin/oh-my-posh
-	sudo chmod +x /usr/local/bin/oh-my-posh
-	@echo "Installing zsh and ohmyzsh - https://ohmyz.sh"
+	@echo "-> Installing oh-my-posh $(OH_MY_POSH_VERSION) - https://ohmyposh.dev"
+	scripts/download-verified \
+		https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$(OH_MY_POSH_VERSION)/posh-linux-amd64 \
+		$(OH_MY_POSH_LINUX_SHA256) /tmp/oh-my-posh
+	sudo install -m 0755 /tmp/oh-my-posh /usr/local/bin/oh-my-posh
+	rm -f /tmp/oh-my-posh
+	@echo "Installing zsh and pinned oh-my-zsh plugins - https://ohmyz.sh"
 	sudo apt-get update
 	sudo apt-get install zsh
-	@echo 'N' | curl https://raw.githubusercontent.com/ohmyzsh/ohmyzsh/master/tools/install.sh | sh
+	git clone https://github.com/ohmyzsh/ohmyzsh.git "${HOME}/.oh-my-zsh"
+	git -C "${HOME}/.oh-my-zsh" checkout --detach $(OH_MY_ZSH_COMMIT)
 	git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "${HOME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"
+	git -C "${HOME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting" checkout --detach $(ZSH_SYNTAX_HIGHLIGHTING_COMMIT)
 	git clone https://github.com/zsh-users/zsh-autosuggestions "${HOME}/.oh-my-zsh/custom/plugins/zsh-autosuggestions"
+	git -C "${HOME}/.oh-my-zsh/custom/plugins/zsh-autosuggestions" checkout --detach $(ZSH_AUTOSUGGESTIONS_COMMIT)
 
 linux: bootstrap-linux
 	./install-profile linux

--- a/README.md
+++ b/README.md
@@ -96,3 +96,24 @@ meta
     ├── <a href="./meta/configs/windows-terminal.yaml" title="windows-terminal.yaml">windows-terminal.yaml</a>
     └── <a href="./meta/configs/zsh.yaml" title="zsh.yaml">zsh.yaml</a>
 </pre>
+
+## Updating pinned installation artifacts
+
+Remote executables and installer inputs are pinned in `Makefile`,
+`remote/Makefile`, and `scripts/install-windows-tools.ps1`. To upgrade one:
+
+1. Change the explicit version or Git commit to the intended upstream release.
+2. Download the artifact from that versioned URL and calculate its SHA-256 digest
+   (`sha256sum <file>` on Linux or `Get-FileHash -Algorithm SHA256 <file>` on
+   Windows). Never take a digest from the same untrusted download location as the
+   artifact without also validating the publisher's signature.
+3. Replace the corresponding checksum, run the checks below, and review the URL
+   scan to ensure no mutable `latest`, `master` raw-download, or piped-shell URL
+   was introduced.
+4. For Git dependencies, update the full commit SHA. Dotbot remains recorded by
+   the repository's submodule gitlink; installers intentionally do not pass
+   `--remote`, so a checkout always installs that recorded revision.
+
+The verified-download helpers write to a temporary file and move it into place
+only after its digest matches. A checksum failure stops installation and removes
+that temporary file.

--- a/install-profile
+++ b/install-profile
@@ -43,7 +43,7 @@ if $dry_run; then
     exit 0
 fi
 
-git submodule update --init --recursive --remote
+git submodule update --init --recursive
 
 "${BASE_DIR}/scripts/backup-dotfiles" "${config_files[@]}"
 

--- a/install-standalone
+++ b/install-standalone
@@ -40,7 +40,7 @@ if $dry_run; then
 fi
 
 cd "${BASE_DIR}"
-git submodule update --init --recursive --remote
+git submodule update --init --recursive
 
 "${BASE_DIR}/scripts/backup-dotfiles" "${config_files[@]}"
 

--- a/remote/Makefile
+++ b/remote/Makefile
@@ -7,12 +7,19 @@ GTOP_VERSION := 1.1.5
 LOCALTUNNEL_VERSION := 2.0.2
 NGROK_VERSION := 5.0.0-beta.2
 CODE_SERVER_VERSION := 4.129.0
-CODE_SERVER_SHA256 := 66160d99431595b0e9f4245abae8d0f472289fb77c97007ce79f2d64d06507f8
+CODE_SERVER_AMD64_SHA256 := 66160d99431595b0e9f4245abae8d0f472289fb77c97007ce79f2d64d06507f8
+CODE_SERVER_ARM64_SHA256 := e504da34067eacc04e03265eccf90e5d2c3fdc3f06c91c2028a5a80f1d05a5b8
 EXTENSION_PACK_VERSION := 1.0.0
 EXTENSION_PACK_SHA256 := 40711c68fe626c202a2fc98f9916ec7e7c0db9d6538394d87d06d7a110d60615
 DOCKER_GPG_SHA256 := 1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
 DOCKER_COMPOSE_VERSION := 5.3.1
-DOCKER_COMPOSE_SHA256 := f9ebc6ebdb19d769b793c245a736caaeb198c62587f13b25c660c13b4987f959
+DOCKER_COMPOSE_X86_64_SHA256 := f9ebc6ebdb19d769b793c245a736caaeb198c62587f13b25c660c13b4987f959
+DOCKER_COMPOSE_AARCH64_SHA256 := aa611e811d0ea25897839c404bfb5bf93ce706dc51c500a4457890f5d0606a86
+DOCKER_COMPOSE_ARMV6_SHA256 := 899607529e5e752cbdaec84b73e994378cf8f27f3d626a5a6df56f7511c00304
+DOCKER_COMPOSE_ARMV7_SHA256 := 69276acb37ea70023cf85a8180e869c0cfc8cb5a3e672821400aa58dea56e2e8
+DOCKER_COMPOSE_PPC64LE_SHA256 := 3280a0dcc7874c2a564ca1224c5669364bc1a5d83ae7153a9c0182fd76fd2102
+DOCKER_COMPOSE_RISCV64_SHA256 := e237f165e0fd5472d147db274f0fb5dcdaab4384c36634178307f4c8e965d904
+DOCKER_COMPOSE_S390X_SHA256 := 3889c8d1677bee347297c8f0a73bc517b5c35da18781812942aef8a87eac9011
 DOWNLOAD_VERIFIED := ../scripts/download-verified
 
 .PHONY: bootstrap code jekyll docker neo4j
@@ -38,7 +45,13 @@ bootstrap:
 
 code:
 	@echo "-> Installing Code Server $(CODE_SERVER_VERSION)"
-	$(DOWNLOAD_VERIFIED) https://github.com/coder/code-server/releases/download/v$(CODE_SERVER_VERSION)/code-server_$(CODE_SERVER_VERSION)_amd64.deb $(CODE_SERVER_SHA256) /tmp/code-server.deb
+	@architecture=$$(dpkg --print-architecture); \
+	case "$$architecture" in \
+		amd64) checksum=$(CODE_SERVER_AMD64_SHA256) ;; \
+		arm64) checksum=$(CODE_SERVER_ARM64_SHA256) ;; \
+		*) echo "Unsupported code-server architecture: $$architecture" >&2; exit 1 ;; \
+	esac; \
+	$(DOWNLOAD_VERIFIED) https://github.com/coder/code-server/releases/download/v$(CODE_SERVER_VERSION)/code-server_$(CODE_SERVER_VERSION)_$$architecture.deb "$$checksum" /tmp/code-server.deb
 	sudo dpkg -i /tmp/code-server.deb
 	rm -f /tmp/code-server.deb
 	@echo "-> Installing Extension Pack $(EXTENSION_PACK_VERSION)"
@@ -63,7 +76,18 @@ docker:
 	sudo apt-get update
 	sudo apt-get install docker-ce docker-ce-cli containerd.io
 	@echo "-> Installing Docker Compose $(DOCKER_COMPOSE_VERSION)"
-	$(DOWNLOAD_VERIFIED) https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-linux-x86_64 $(DOCKER_COMPOSE_SHA256) /tmp/docker-compose
+	@architecture=$$(uname -m); \
+	case "$$architecture" in \
+		x86_64) checksum=$(DOCKER_COMPOSE_X86_64_SHA256) ;; \
+		aarch64) checksum=$(DOCKER_COMPOSE_AARCH64_SHA256) ;; \
+		armv6l) architecture=armv6; checksum=$(DOCKER_COMPOSE_ARMV6_SHA256) ;; \
+		armv7l) architecture=armv7; checksum=$(DOCKER_COMPOSE_ARMV7_SHA256) ;; \
+		ppc64le) checksum=$(DOCKER_COMPOSE_PPC64LE_SHA256) ;; \
+		riscv64) checksum=$(DOCKER_COMPOSE_RISCV64_SHA256) ;; \
+		s390x) checksum=$(DOCKER_COMPOSE_S390X_SHA256) ;; \
+		*) echo "Unsupported Docker Compose architecture: $$architecture" >&2; exit 1 ;; \
+	esac; \
+	$(DOWNLOAD_VERIFIED) https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-linux-$$architecture "$$checksum" /tmp/docker-compose
 	sudo install -m 0755 /tmp/docker-compose /usr/local/bin/docker-compose
 	rm -f /tmp/docker-compose
 

--- a/remote/Makefile
+++ b/remote/Makefile
@@ -1,10 +1,21 @@
 # Default target
 .DEFAULT_GOAL := help
 
-# PHONY
-.PHONY: bootstrap code jekyll docker neo4j
+# Pinned upstream versions and checksums. See ../README.md before updating.
+NPM_VERSION := 12.0.1
+GTOP_VERSION := 1.1.5
+LOCALTUNNEL_VERSION := 2.0.2
+NGROK_VERSION := 5.0.0-beta.2
+CODE_SERVER_VERSION := 4.129.0
+CODE_SERVER_SHA256 := 66160d99431595b0e9f4245abae8d0f472289fb77c97007ce79f2d64d06507f8
+EXTENSION_PACK_VERSION := 1.0.0
+EXTENSION_PACK_SHA256 := 40711c68fe626c202a2fc98f9916ec7e7c0db9d6538394d87d06d7a110d60615
+DOCKER_GPG_SHA256 := 1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
+DOCKER_COMPOSE_VERSION := 5.3.1
+DOCKER_COMPOSE_SHA256 := f9ebc6ebdb19d769b793c245a736caaeb198c62587f13b25c660c13b4987f959
+DOWNLOAD_VERIFIED := ../scripts/download-verified
 
-# Targets
+.PHONY: bootstrap code jekyll docker neo4j
 
 help :
 	@echo "bootstrap : Bootstrap Environment"
@@ -13,68 +24,49 @@ help :
 	@echo "docker    : Install Docker"
 	@echo "neo4j     : Install Neo4j"
 
-# Initialize
 bootstrap:
 	@echo "-> Bootstraping Environment"
 	sudo apt update
 	@echo "--> Installing required tools and utilities"
-	sudo apt install \
-		build-essential \
-		httpie \
-		nano \
-		software-properties-common \
-		ca-certificates \
-		gnupg \
-		lsb-release \
-		openssh-server
-	@echo "--> Updating NPM"
-	npm install -g npm
-	@echo "--> NPM Updated"
-	@echo "--> Installing gtop - https://github.com/aksakalli/gtop"
-	npm install -g gtop
-	@echo "--> gtop installtion complete"
-	@echo "--> Installing localtunnel - https://github.com/localtunnel/localtunnel"
-	npm install -g localtunnel
-	@echo "--> localtunnel installtion complete"
-	@echo "--> Installing ngrok - https://ngrok.com"
-	wget https://bin.equinox.io/c/4VmDzA7iaHb/ngrok-stable-linux-amd64.zip
-	unzip ngrok-stable-linux-amd64.zip
-	@echo "--> ngrok installtion complete"
+	sudo apt install build-essential httpie nano software-properties-common ca-certificates gnupg lsb-release openssh-server
+	@echo "--> Installing pinned NPM utilities (registry integrity is verified by npm)"
+	npm install -g npm@$(NPM_VERSION)
+	npm install -g gtop@$(GTOP_VERSION)
+	npm install -g localtunnel@$(LOCALTUNNEL_VERSION)
+	npm install -g ngrok@$(NGROK_VERSION)
 	@echo "-> Bootstrap Complete"
 
-# Install Code Server
 code:
-	@echo "-> Installing Code Server - https://github.com/cdr/code-server"
-	curl -fsSL https://code-server.dev/install.sh | sh
-	@echo "-> Code Server installtion complete"
-	@echo "-> Installing Extension Pack for VSCode - https://github.com/adisakshya/extension-pack"
-	curl https://github.com/adisakshya/extension-pack/releases/latest/download/adisakshya-extension-pack.vsix -O -L
-	code-server --install-extension adisakshya-extension-pack.vsix
-	@echo "-> Extension Pack installation complete"
+	@echo "-> Installing Code Server $(CODE_SERVER_VERSION)"
+	$(DOWNLOAD_VERIFIED) https://github.com/coder/code-server/releases/download/v$(CODE_SERVER_VERSION)/code-server_$(CODE_SERVER_VERSION)_amd64.deb $(CODE_SERVER_SHA256) /tmp/code-server.deb
+	sudo dpkg -i /tmp/code-server.deb
+	rm -f /tmp/code-server.deb
+	@echo "-> Installing Extension Pack $(EXTENSION_PACK_VERSION)"
+	$(DOWNLOAD_VERIFIED) https://github.com/adisakshya/extension-pack/releases/download/v$(EXTENSION_PACK_VERSION)/adisakshya-extension-pack.vsix $(EXTENSION_PACK_SHA256) /tmp/adisakshya-extension-pack.vsix
+	code-server --install-extension /tmp/adisakshya-extension-pack.vsix
+	rm -f /tmp/adisakshya-extension-pack.vsix
 
-# Install Jekyll
 jekyll:
 	@echo "-> Installing Ruby"
 	sudo apt update
 	sudo apt-get install ruby-full patch zlib1g-dev build-essential -y
 	@echo "-> Installing Jekyll and Bundler"
 	gem install jekyll bundler
-	@echo "-> Jekyll installtion complete"
 
-# Install Docker
+# Docker packages are authenticated by apt using the checksum-verified signing key.
 docker:
 	@echo "-> Installing Docker"
-	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo gpg --dearmor -o /usr/share/keyrings/docker-archive-keyring.gpg
-	@echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+	$(DOWNLOAD_VERIFIED) https://download.docker.com/linux/ubuntu/gpg $(DOCKER_GPG_SHA256) /tmp/docker.gpg
+	sudo gpg --dearmor --yes -o /usr/share/keyrings/docker-archive-keyring.gpg /tmp/docker.gpg
+	rm -f /tmp/docker.gpg
+	@echo "deb [arch=$$(dpkg --print-architecture) signed-by=/usr/share/keyrings/docker-archive-keyring.gpg] https://download.docker.com/linux/ubuntu $$(lsb_release -cs) stable" | sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
 	sudo apt-get update
 	sudo apt-get install docker-ce docker-ce-cli containerd.io
-	@echo "-> Docker installtion complete"
-	@echo "-> Installing Docker Compose"
-	curl -L "https://github.com/docker/compose/releases/download/1.29.2/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-	chmod +x /usr/local/bin/docker-compose
-	@echo "-> Docker Compose installtion complete"
+	@echo "-> Installing Docker Compose $(DOCKER_COMPOSE_VERSION)"
+	$(DOWNLOAD_VERIFIED) https://github.com/docker/compose/releases/download/v$(DOCKER_COMPOSE_VERSION)/docker-compose-linux-x86_64 $(DOCKER_COMPOSE_SHA256) /tmp/docker-compose
+	sudo install -m 0755 /tmp/docker-compose /usr/local/bin/docker-compose
+	rm -f /tmp/docker-compose
 
-# Install Neo4j
 neo4j:
 	@echo "-> Installing Neo4j"
 	@echo "-> Neo4j installtion complete"

--- a/scripts/download-verified
+++ b/scripts/download-verified
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+if (( $# != 3 )); then
+    echo "Usage: $0 <url> <sha256> <destination>" >&2
+    exit 2
+fi
+
+url=$1
+expected_sha256=$2
+destination=$3
+temporary="${destination}.download-$$"
+trap 'rm -f "$temporary"' EXIT
+
+curl --fail --location --silent --show-error "$url" --output "$temporary"
+printf '%s  %s\n' "$expected_sha256" "$temporary" | sha256sum --check --status
+mv "$temporary" "$destination"

--- a/scripts/install-windows-tools.ps1
+++ b/scripts/install-windows-tools.ps1
@@ -1,0 +1,20 @@
+$ErrorActionPreference = 'Stop'
+
+$OhMyPoshVersion = '29.34.0'
+$OhMyPoshSha256 = '4de216d90a1432ae00fa0aceeef189b7e0fae470574b2c33a3927ea5f0d5ac15'
+$OhMyPoshUrl = "https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$OhMyPoshVersion/posh-windows-amd64.exe"
+$InstallDirectory = Join-Path $env:LOCALAPPDATA 'Programs\oh-my-posh\bin'
+$TemporaryFile = Join-Path ([System.IO.Path]::GetTempPath()) "oh-my-posh-$OhMyPoshVersion.exe"
+
+try {
+    Invoke-WebRequest -UseBasicParsing -Uri $OhMyPoshUrl -OutFile $TemporaryFile
+    $ActualSha256 = (Get-FileHash -Algorithm SHA256 $TemporaryFile).Hash.ToLowerInvariant()
+    if ($ActualSha256 -ne $OhMyPoshSha256) {
+        throw "Checksum mismatch for oh-my-posh $OhMyPoshVersion"
+    }
+
+    New-Item -ItemType Directory -Force -Path $InstallDirectory | Out-Null
+    Move-Item -Force $TemporaryFile (Join-Path $InstallDirectory 'oh-my-posh.exe')
+} finally {
+    Remove-Item -Force -ErrorAction SilentlyContinue $TemporaryFile
+}

--- a/scripts/install-windows-tools.ps1
+++ b/scripts/install-windows-tools.ps1
@@ -15,6 +15,18 @@ try {
 
     New-Item -ItemType Directory -Force -Path $InstallDirectory | Out-Null
     Move-Item -Force $TemporaryFile (Join-Path $InstallDirectory 'oh-my-posh.exe')
+
+    $UserPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+    $UserPathEntries = @($UserPath -split ';' | Where-Object { $_ })
+    if (-not ($UserPathEntries | Where-Object { $_.Equals($InstallDirectory, [StringComparison]::OrdinalIgnoreCase) })) {
+        $UpdatedUserPath = ($UserPathEntries + $InstallDirectory) -join ';'
+        [Environment]::SetEnvironmentVariable('Path', $UpdatedUserPath, 'User')
+    }
+
+    $ProcessPathEntries = @($env:Path -split ';' | Where-Object { $_ })
+    if (-not ($ProcessPathEntries | Where-Object { $_.Equals($InstallDirectory, [StringComparison]::OrdinalIgnoreCase) })) {
+        $env:Path = ($ProcessPathEntries + $InstallDirectory) -join ';'
+    }
 } finally {
     Remove-Item -Force -ErrorAction SilentlyContinue $TemporaryFile
 }

--- a/tests/download-verified.sh
+++ b/tests/download-verified.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_DIR="$(mktemp -d)"
+trap 'rm -rf "$TEST_DIR"' EXIT
+
+printf 'verified payload\n' > "$TEST_DIR/source"
+checksum="$(sha256sum "$TEST_DIR/source" | cut -d ' ' -f 1)"
+"$ROOT/scripts/download-verified" "file://$TEST_DIR/source" "$checksum" "$TEST_DIR/output"
+cmp "$TEST_DIR/source" "$TEST_DIR/output"
+
+if "$ROOT/scripts/download-verified" "file://$TEST_DIR/source" \
+    0000000000000000000000000000000000000000000000000000000000000000 \
+    "$TEST_DIR/rejected" 2>/dev/null; then
+    echo "expected a checksum mismatch to fail" >&2
+    exit 1
+fi
+[[ ! -e "$TEST_DIR/rejected" ]]
+! find "$TEST_DIR" -name 'rejected.download-*' | grep -q .
+
+echo "download-verified tests passed"

--- a/tests/pinned-installers.sh
+++ b/tests/pinned-installers.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+
+! grep -E -- '--remote|releases/latest|raw\.githubusercontent\.com/.*/master|curl[^|]*\|[[:space:]]*(sh|bash)|iwr[^|]*\|' \
+    "$ROOT/Makefile" "$ROOT/remote/Makefile" "$ROOT/install-profile" \
+    "$ROOT/install-standalone" "$ROOT/scripts/install-windows-tools.ps1"
+grep -q 'sha256sum --check' "$ROOT/scripts/download-verified"
+grep -q 'Get-FileHash -Algorithm SHA256' "$ROOT/scripts/install-windows-tools.ps1"
+
+echo "pinned installer checks passed"

--- a/tests/pinned-installers.sh
+++ b/tests/pinned-installers.sh
@@ -9,5 +9,13 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
     "$ROOT/install-standalone" "$ROOT/scripts/install-windows-tools.ps1"
 grep -q 'sha256sum --check' "$ROOT/scripts/download-verified"
 grep -q 'Get-FileHash -Algorithm SHA256' "$ROOT/scripts/install-windows-tools.ps1"
+grep -q "SetEnvironmentVariable('Path', \$UpdatedUserPath, 'User')" \
+    "$ROOT/scripts/install-windows-tools.ps1"
+
+remote_makefile="$ROOT/remote/Makefile"
+grep -q 'architecture=$$(dpkg --print-architecture)' "$remote_makefile"
+grep -q 'CODE_SERVER_ARM64_SHA256' "$remote_makefile"
+grep -q 'architecture=$$(uname -m)' "$remote_makefile"
+grep -q 'DOCKER_COMPOSE_AARCH64_SHA256' "$remote_makefile"
 
 echo "pinned installer checks passed"


### PR DESCRIPTION
### Motivation

- Prevent installation-time supply-chain risks by avoiding mutable `latest` redirects and piped-shell installs and ensuring artifacts are reproducible and integrity-checked.
- Ensure installer steps use the repository-recorded revisions for submodules rather than following remote tips.

### Description

- Add a `scripts/download-verified` helper that downloads to a temporary file, verifies a provided SHA-256, and atomically moves the file into place, and add a Windows PowerShell verifier at `scripts/install-windows-tools.ps1` to perform the same check on Windows.
- Replace mutable/piped downloads with version-pinned URLs and checksums in `Makefile` and `remote/Makefile`, pin upstream versions and commit SHAs for Oh My Posh, code-server, extension pack, Docker Compose, npm tools, and zsh plugins, and use the verified-download helper where appropriate.
- Remove `--remote` from `git submodule update` invocations in `install-profile` and `install-standalone` so installers use the repository-recorded submodule revisions.
- Document the pinned-upgrade process in `README.md` and add tests `tests/download-verified.sh` and `tests/pinned-installers.sh` that assert checksum verification, temporary-file cleanup, and absence of mutable or piped-shell installer patterns.
- Changes are placed on a new branch `fix/pin-install-artifacts` and prepared for a pull request closing issue #6.

### Testing

- Ran `./tests/download-verified.sh` and it passed (checks successful + checksum mismatch rejected).
- Ran `./tests/pinned-installers.sh` and it passed (no `--remote`, `releases/latest`, piped-shell, or raw master downloads; verification helpers present).
- Ran existing `./tests/backup-dotfiles.sh` and it passed to validate unchanged backup behavior.
- Performed static checks: `bash -n install-profile install-standalone scripts/backup-dotfiles scripts/download-verified tests/*.sh` (no syntax errors), `make -n bootstrap-linux`, and `make -C remote -n bootstrap code docker` (dry-run make executions succeeded); `git diff --check` reported no trailing whitespace or check errors.
- Note: `shellcheck` was not available in the environment so those lint checks were not executed here.
