### PR TITLE
fix: add backup-existing.sh and document manual backup step

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,23 @@ configs without modifying the filesystem or updating submodules:
 desired file from its timestamped directory back to the corresponding path in
 your home directory after removing the generated symlink.
 
+To run the backup step in isolation — without touching submodules or creating
+any symlinks — use the helper script at the repository root:
+
+```bash
+# Preview what would be backed up for the linux profile
+./backup-existing.sh --dry-run --profile linux
+
+# Back up without installing
+./backup-existing.sh --profile linux
+
+# Back up specific configs only
+./backup-existing.sh --configs bash zsh essentials
+```
+
+This is useful when you want to inspect or preserve existing dotfiles before
+committing to a full install.
+
 ### Re-running / Idempotency
 
 Dotbot skips symlinks that already exist and already point to the correct target, so re-running `./install-profile <profile>` is safe. Only destinations that are missing or point elsewhere are updated (after the usual backup step described above).

--- a/backup-existing.sh
+++ b/backup-existing.sh
@@ -73,6 +73,7 @@ case "${1:-}" in
             exit 2
         fi
         for config in "$@"; do
+            config="${config%-sudo}"
             config_files+=("${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${config}${CONFIG_SUFFIX}")
         done
         ;;

--- a/backup-existing.sh
+++ b/backup-existing.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+
+# Back up pre-existing dotfiles that would be managed by this repository.
+# Copies are written to $HOME/.dotfiles-backups/<timestamp>-<pid>/ (or the
+# directory named by $DOTFILES_BACKUP_DIR).
+#
+# Run this before the first install on a machine that already has dotfiles you
+# want to keep.  The install scripts call the same backup logic automatically,
+# but this script lets you inspect or trigger the backup step independently.
+#
+# Usage:
+#   ./backup-existing.sh [--dry-run] --profile <profile>
+#   ./backup-existing.sh [--dry-run] --configs <config>...
+#
+# Examples:
+#   ./backup-existing.sh --dry-run --profile linux
+#   ./backup-existing.sh --profile linux
+#   ./backup-existing.sh --configs bash zsh essentials
+
+set -euo pipefail
+
+CONFIG_SUFFIX=".yaml"
+META_DIR="meta"
+CONFIG_DIR="configs"
+PROFILES_DIR="profiles"
+BASE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+usage() {
+    echo "Usage: $0 [--dry-run] --profile <profile>" >&2
+    echo "       $0 [--dry-run] --configs <config>..." >&2
+    echo "" >&2
+    echo "Options:" >&2
+    echo "  --dry-run   Show what would be backed up without copying anything" >&2
+    echo "  --profile   Back up destinations for all configs in the named profile" >&2
+    echo "  --configs   Back up destinations for the listed config name(s)" >&2
+}
+
+dry_run_flag=()
+if [[ ${1:-} == "--dry-run" ]]; then
+    dry_run_flag=(--dry-run)
+    shift
+fi
+
+if (( $# == 0 )); then
+    usage
+    exit 2
+fi
+
+config_files=()
+
+case "${1:-}" in
+    --profile)
+        shift
+        if (( $# == 0 )); then
+            echo "Error: --profile requires a profile name" >&2
+            usage
+            exit 2
+        fi
+        profile_file="${BASE_DIR}/${META_DIR}/${PROFILES_DIR}/$1"
+        [[ -f "$profile_file" ]] || { echo "Unknown profile: $1" >&2; exit 1; }
+        mapfile -t lines < "$profile_file"
+        for config in "${lines[@]}"; do
+            profileConfigName=${config//$'\t\r\n'/}
+            [[ -n "$profileConfigName" ]] || continue
+            config_files+=("${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${profileConfigName}${CONFIG_SUFFIX}")
+        done
+        ;;
+    --configs)
+        shift
+        if (( $# == 0 )); then
+            echo "Error: --configs requires at least one config name" >&2
+            usage
+            exit 2
+        fi
+        for config in "$@"; do
+            config_files+=("${BASE_DIR}/${META_DIR}/${CONFIG_DIR}/${config}${CONFIG_SUFFIX}")
+        done
+        ;;
+    *)
+        usage
+        exit 2
+        ;;
+esac
+
+if (( ${#config_files[@]} == 0 )); then
+    echo "No config files resolved." >&2
+    exit 1
+fi
+
+exec "${BASE_DIR}/scripts/backup-dotfiles" "${dry_run_flag[@]}" "${config_files[@]}"

--- a/meta/force-links-after-backup.yaml
+++ b/meta/force-links-after-backup.yaml
@@ -1,3 +1,7 @@
+# This fragment is appended by install-profile and install-standalone *after*
+# scripts/backup-dotfiles has saved a timestamped copy of every pre-existing
+# file at a managed destination.  Do not use it in isolation — always run the
+# backup step first so that force-relinking cannot cause data loss.
 - defaults:
     link:
       force: true


### PR DESCRIPTION
## Summary

Closes #5

The core safety fixes for issue #5 were already in master (backup before
relinking, `force: true` scoped to after-backup only, `--dry-run` mode,
and README documentation). This PR adds the remaining pieces to fully
close the issue:

- **`backup-existing.sh`** — a user-facing script at the repo root that
  lets users run the backup step independently, before or without
  triggering a full install. Accepts `--dry-run`, `--profile <name>`, and
  `--configs <name>...` flags. Delegates to the existing
  `scripts/backup-dotfiles` implementation so there is no logic
  duplication.
- **`meta/force-links-after-backup.yaml`** — adds a comment making the
  safety contract explicit: this fragment must only ever be appended after
  the backup step has run, not used in isolation.
- **README** — expands the "Existing files and dry runs" section with
  concrete `backup-existing.sh` examples so users know they can inspect
  or trigger a backup without committing to a full install.

## Acceptance criteria (from #5)

- Running `install-profile` on a machine with pre-existing dotfiles does
  not delete any file without first creating a backup. ✓ (already in
  master via `scripts/backup-dotfiles`)
- The backup location and naming convention are documented. ✓ (README)
- The README warns about the overwrite behaviour. ✓ (README)

## Test plan

- [ ] `bash -n backup-existing.sh` passes (no syntax errors)
- [ ] `./backup-existing.sh --dry-run --profile linux` prints the paths
  that would be backed up without touching the filesystem
- [ ] `./backup-existing.sh --profile linux` creates a timestamped
  directory under `~/.dotfiles-backups/` containing copies of any
  pre-existing managed files
- [ ] `./backup-existing.sh --configs bash zsh` works for individual
  config names
- [ ] Running `./install-profile linux` on a machine with pre-existing
  `~/.zshrc` still backs the file up before symlinking