### PR TITLE
fix: pin dependency versions and remove --remote submodule flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,10 @@ git clone https://github.com/adisakshya/dotfiles ~/.dotfiles && cd ~/.dotfiles
 
 Dotfiles can be installed either using the [Makefile](./Makefile) or the dotbot install-scripts.
 
-The Makefile contain bootstrap scripts helping in installing prerequisites and utilities -
-- Source Code Pro Powerline Font
-- Oh My Posh
-- Scoop (for Windows)
-- ZSH, Oh My ZSH and required ZSH plugins (for Linux)
+The Makefile contains bootstrap scripts that install the following pinned and checksum-verified dependencies:
+- Source Code Pro Powerline Font (all platforms)
+- Oh My Posh (all platforms, pinned to an explicit version with SHA-256 verification)
+- ZSH, Oh My ZSH, and required ZSH plugins (Linux only, pinned to specific Git commits)
 
 After installing these prerequisites the symlinks are created for the chosen profile using dotbot install-script.
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,11 @@ git clone https://github.com/adisakshya/dotfiles ~/.dotfiles && cd ~/.dotfiles
 
 Dotfiles can be installed either using the [Makefile](./Makefile) or the dotbot install-scripts.
 
-The Makefile contains bootstrap scripts that install the following pinned and checksum-verified dependencies:
+The Makefile contains bootstrap scripts that install the following dependencies. Oh My Posh, Oh My ZSH, and ZSH plugins are pinned and checksum-verified; ZSH itself is installed via the system package manager without a version pin.
 - Source Code Pro Powerline Font (all platforms)
 - Oh My Posh (all platforms, pinned to an explicit version with SHA-256 verification)
-- ZSH, Oh My ZSH, and required ZSH plugins (Linux only, pinned to specific Git commits)
+- Oh My ZSH and required ZSH plugins (Linux only, pinned to specific Git commit SHAs)
+- ZSH (Linux only, installed via apt-get without a version pin)
 
 After installing these prerequisites the symlinks are created for the chosen profile using dotbot install-script.
 


### PR DESCRIPTION
## Summary

Closes #6

All mutable or unverified remote downloads have been addressed:

- **Oh My Posh (Linux):** Replaced `/releases/latest/` URL with an explicit pinned version (`OH_MY_POSH_VERSION`) downloaded via `scripts/download-verified`, which writes to a temp file and aborts if the SHA-256 digest does not match `OH_MY_POSH_LINUX_SHA256`.
- **Oh My Posh (Windows):** `scripts/install-windows-tools.ps1` downloads from a pinned version URL and verifies the SHA-256 digest in PowerShell before moving the binary into place.
- **Oh My ZSH and plugins:** Replaced the `curl … | sh` pipe pattern with `git clone` followed by `git checkout --detach <commit-sha>` so the exact revision is always installed.
- **code-server:** Replaced the unversioned `install.sh | sh` pipe with a checksum-verified `.deb` download using `scripts/download-verified` and `CODE_SERVER_VERSION` / per-architecture SHA-256 variables.
- **VS Code extension pack:** Pinned to `EXTENSION_PACK_VERSION` with `EXTENSION_PACK_SHA256` verified via `download-verified`.
- **ngrok:** Moved to `npm install -g ngrok@$(NGROK_VERSION)`; npm verifies registry integrity on install.
- **Submodules:** Removed `--remote` from `git submodule update` in `install-profile` and `install-standalone` so submodules always check out the SHA recorded in the repository rather than pulling the tip of the remote branch.
- **Scoop:** Removed from the Windows bootstrap entirely; oh-my-posh is now installed directly with checksum verification.

## Documentation

- Added an "Updating pinned installation artifacts" section to `README.md` explaining the step-by-step process for bumping a pinned version (change version variable → compute new SHA-256 → update checksum → verify).
- Corrected the README dependency list to accurately reflect the current pinned, checksum-verified approach and remove the stale Scoop reference.
- Version and checksum variables are grouped at the top of each Makefile with a comment pointing to `README.md` for update instructions.

## Test plan

- [ ] `make linux` completes successfully on a clean Ubuntu VM and the SHA-256 check for oh-my-posh passes
- [ ] `make windows` completes successfully and the PowerShell SHA-256 check for oh-my-posh passes
- [ ] `make code` in `remote/` installs the correct code-server version with checksum verified
- [ ] Deliberately corrupting a checksum variable causes installation to fail with a clear error
- [ ] `./install-profile linux` and `./install-standalone bash` both succeed without the `--remote` flag
- [ ] A fresh clone followed by install produces the same result as a previous install at the same version

---
_Generated by [Claude Code](https://claude.ai/code/session_01RF2UoiRKcQiHhVpF1GDSBV)_