### PR TITLE
fix: add trap-based temp file cleanup to install scripts

### DIFF
--- a/install-profile
+++ b/install-profile
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+configFile=
+trap 'rm -f "${configFile:-}"' EXIT
+
 BASE_CONFIG="base"
 FORCE_CONFIG="force-links-after-backup"
 CONFIG_SUFFIX=".yaml"
@@ -57,6 +60,7 @@ for config in "${lines[@]}"; do
     cmd=("${BASE_DIR}/${META_DIR}/${DOTBOT_DIR}/${DOTBOT_BIN}" -d "${BASE_DIR}" -c "$configFile")
     "${cmd[@]}"
     rm -f "$configFile"
+    configFile=
 done
 
 cd "${BASE_DIR}"

--- a/install-standalone
+++ b/install-standalone
@@ -2,6 +2,9 @@
 
 set -euo pipefail
 
+configFile=
+trap 'rm -f "${configFile:-}"' EXIT
+
 BASE_CONFIG="base"
 FORCE_CONFIG="force-links-after-backup"
 CONFIG_SUFFIX=".yaml"
@@ -62,6 +65,7 @@ for config in "$@"; do
 
     "${cmd[@]}"
     rm -f "$configFile"
+    configFile=
 done
 
 cd "${BASE_DIR}"


### PR DESCRIPTION
## Problem

Closes #7.

Both `install-profile` and `install-standalone` create a temp file (via `mktemp`) inside a `for` loop and remove it with `rm -f "$configFile"` at the end of each iteration. With `set -e` active, an unexpected exit — for example if the `dotbot` command fails mid-loop, or the script is killed — causes the script to terminate immediately, bypassing the `rm -f` and leaving the current temp file on disk.

## Changes

Both scripts already had the other items from issue #7 addressed (`set -euo pipefail`, argument count validation, quoted variable and array expansions). This PR adds the remaining fix: `trap`-based cleanup.

For each script:

- **Declare `configFile=` at the top** so the variable is always defined when the trap fires (required for `set -u` compatibility).
- **Register `trap 'rm -f "${configFile:-}"' EXIT`** immediately after the strict-mode line. This fires on every exit path — normal completion, `set -e` triggered exit, signal, or explicit `exit` call.
- **Reset `configFile=` after each explicit `rm -f` in the loop** so the trap handler is a no-op on the happy path; it only does real work when the loop exits mid-iteration.

## Verification

- Calling either script with no arguments still prints a usage message and exits non-zero (argument validation was already in place).
- No ShellCheck warnings are introduced (ShellCheck is satisfied by `${configFile:-}` which avoids the unbound-variable error that `$configFile` would trigger under `set -u` when the variable is empty).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RF2UoiRKcQiHhVpF1GDSBV)_