### PR TITLE
fix: detect CPU architecture and package manager in Linux bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,11 @@
 
 # Pinned upstream revisions. See README.md before updating these values.
 OH_MY_POSH_VERSION := 29.34.0
-OH_MY_POSH_LINUX_SHA256 := 90f33e71f181e959f1511d03f05ee0843c5eab4d7799e2d479a13c3fdd5b7c44
+# Arch-specific SHA-256 digests for the oh-my-posh Linux binary.
+# Update all three values when bumping OH_MY_POSH_VERSION.
+OH_MY_POSH_LINUX_AMD64_SHA256 := 90f33e71f181e959f1511d03f05ee0843c5eab4d7799e2d479a13c3fdd5b7c44
+OH_MY_POSH_LINUX_ARM64_SHA256 := f2b470d6b46ddea386730d081ce4a11aeb3a347ed54cda667815e70d8a4f5edb
+OH_MY_POSH_LINUX_ARM_SHA256   := fbb9391daa3a6b7af5c184599c0fe2141d3ac5827461f5cdb2ac3d976675d158
 OH_MY_ZSH_COMMIT := 59a9740721b734835812121322d6fe4827b0853a
 ZSH_SYNTAX_HIGHLIGHTING_COMMIT := 1d85c692615a25fe2293bdd44b34c217d5d2bf04
 ZSH_AUTOSUGGESTIONS_COMMIT := 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5
@@ -37,14 +41,20 @@ bootstrap-linux:
 	@echo "Install Powerline font - Source Code Pro - https://github.com/powerline/fonts"
 	sh common/fonts/install.sh
 	@echo "-> Installing oh-my-posh $(OH_MY_POSH_VERSION) - https://ohmyposh.dev"
+	@architecture=$$(uname -m); \
+	case "$$architecture" in \
+		x86_64)        omp_arch=amd64; checksum=$(OH_MY_POSH_LINUX_AMD64_SHA256) ;; \
+		aarch64|arm64) omp_arch=arm64; checksum=$(OH_MY_POSH_LINUX_ARM64_SHA256) ;; \
+		armv7l|armv6l) omp_arch=arm;   checksum=$(OH_MY_POSH_LINUX_ARM_SHA256)   ;; \
+		*) echo "Unsupported architecture: $$architecture" >&2; exit 1 ;; \
+	esac; \
 	scripts/download-verified \
-		https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$(OH_MY_POSH_VERSION)/posh-linux-amd64 \
-		$(OH_MY_POSH_LINUX_SHA256) /tmp/oh-my-posh
+		https://github.com/JanDeDobbeleer/oh-my-posh/releases/download/v$(OH_MY_POSH_VERSION)/posh-linux-$$omp_arch \
+		$$checksum /tmp/oh-my-posh
 	sudo install -m 0755 /tmp/oh-my-posh /usr/local/bin/oh-my-posh
 	rm -f /tmp/oh-my-posh
 	@echo "Installing zsh and pinned oh-my-zsh plugins - https://ohmyz.sh"
-	sudo apt-get update
-	sudo apt-get install zsh
+	scripts/install-zsh.sh
 	git clone https://github.com/ohmyzsh/ohmyzsh.git "${HOME}/.oh-my-zsh"
 	git -C "${HOME}/.oh-my-zsh" checkout --detach $(OH_MY_ZSH_COMMIT)
 	git clone https://github.com/zsh-users/zsh-syntax-highlighting.git "${HOME}/.oh-my-zsh/custom/plugins/zsh-syntax-highlighting"

--- a/README.md
+++ b/README.md
@@ -19,8 +19,10 @@ Adisakshya's dotfiles!
 
 ### Linux
 
-- **`git`, `curl`, `zsh`** — install via your distro's package manager, e.g. `sudo apt-get install git curl zsh`.
+- **`git` and `curl`** — install via your distro's package manager before running `make linux`.
 - **`sudo` access** — required for package installation and writing to `/usr/local/bin`.
+- **Supported distributions** — Ubuntu/Debian (`apt-get`), Fedora/RHEL (`dnf`), Arch Linux (`pacman`), and Alpine (`apk`). The bootstrap installs `zsh` automatically using the detected package manager.
+- **Supported CPU architectures** — x86\_64 (amd64), aarch64/arm64, and armv7l/armv6l (arm).
 
 ## Installation
 
@@ -36,7 +38,7 @@ The Makefile contains bootstrap scripts that install the following dependencies.
 - Source Code Pro Powerline Font (all platforms)
 - Oh My Posh (all platforms, pinned to an explicit version with SHA-256 verification)
 - Oh My ZSH and required ZSH plugins (Linux only, pinned to specific Git commit SHAs)
-- ZSH (Linux only, installed via apt-get without a version pin)
+- ZSH (Linux only, installed via the detected system package manager without a version pin)
 
 After installing these prerequisites the symlinks are created for the chosen profile using dotbot install-script.
 

--- a/scripts/install-zsh.sh
+++ b/scripts/install-zsh.sh
@@ -1,8 +1,8 @@
-#!/usr/bin/env bash
+#!/bin/sh
 # Install zsh using the system package manager.
 # Supports apt-get (Debian/Ubuntu), dnf (Fedora/RHEL), pacman (Arch), and apk (Alpine).
 
-set -euo pipefail
+set -eu
 
 if command -v apt-get >/dev/null 2>&1; then
     sudo apt-get update
@@ -10,7 +10,7 @@ if command -v apt-get >/dev/null 2>&1; then
 elif command -v dnf >/dev/null 2>&1; then
     sudo dnf install -y zsh
 elif command -v pacman >/dev/null 2>&1; then
-    sudo pacman -Sy --noconfirm zsh
+    sudo pacman -Syu --noconfirm zsh
 elif command -v apk >/dev/null 2>&1; then
     sudo apk add --no-cache zsh
 else

--- a/scripts/install-zsh.sh
+++ b/scripts/install-zsh.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Install zsh using the system package manager.
+# Supports apt-get (Debian/Ubuntu), dnf (Fedora/RHEL), pacman (Arch), and apk (Alpine).
+
+set -euo pipefail
+
+if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y zsh
+elif command -v dnf >/dev/null 2>&1; then
+    sudo dnf install -y zsh
+elif command -v pacman >/dev/null 2>&1; then
+    sudo pacman -Sy --noconfirm zsh
+elif command -v apk >/dev/null 2>&1; then
+    sudo apk add --no-cache zsh
+else
+    echo "No supported package manager found (apt-get, dnf, pacman, apk)." >&2
+    echo "Please install zsh manually before running 'make linux'." >&2
+    exit 1
+fi


### PR DESCRIPTION
## Problem

The Linux bootstrap (`make linux`) unconditionally downloaded the `amd64` oh-my-posh binary and called `apt-get` to install zsh, making the advertised Linux installation fail silently on ARM machines and break entirely on non-Debian distributions.

Fixes #10.

## Changes

### `Makefile`

- Replaced the single hardcoded `OH_MY_POSH_LINUX_SHA256` variable with three arch-specific variables:
  - `OH_MY_POSH_LINUX_AMD64_SHA256`
  - `OH_MY_POSH_LINUX_ARM64_SHA256`
  - `OH_MY_POSH_LINUX_ARM_SHA256`
- Added a `case "$architecture"` block (using the same shell pattern already used in `remote/Makefile` for Docker Compose) that maps `uname -m` output to the correct oh-my-posh binary arch suffix (`amd64`, `arm64`, or `arm`) and selects the matching pinned checksum.
- Exits with a clear error message on any unsupported architecture.
- Replaced the two hardcoded `apt-get` lines with a call to the new `scripts/install-zsh.sh`.

### `scripts/install-zsh.sh` (new)

Detects the available package manager at runtime and installs zsh:

| Package manager | Distribution family |
|---|---|
| `apt-get` | Debian / Ubuntu |
| `dnf` | Fedora / RHEL |
| `pacman` | Arch Linux |
| `apk` | Alpine |

Exits with an informative error if none of the above is found.

### `README.md`

Updated the Linux Prerequisites section to document:
- Supported distributions (Debian/Ubuntu, Fedora/RHEL, Arch Linux, Alpine)
- Supported CPU architectures (x86_64/amd64, aarch64/arm64, armv7l/armv6l/arm)

## Test plan

- [ ] All existing tests pass (`tests/pinned-installers.sh`, `tests/download-verified.sh`)
- [ ] `make linux` completes successfully on an x86_64 Debian/Ubuntu machine
- [ ] `make linux` completes successfully on an aarch64 machine
- [ ] `make linux` prints a clear error on an unsupported architecture
- [ ] `make linux` installs zsh via `dnf` on a Fedora machine
- [ ] `make linux` installs zsh via `pacman` on an Arch Linux machine
- [ ] `make linux` exits with a clear error when no supported package manager is present

---
_Generated by [Claude Code](https://claude.ai/code/session_01RF2UoiRKcQiHhVpF1GDSBV)_