### PR TITLE
fix: update PowerShell profile to current Oh My Posh API and add PS7 path

### DIFF
--- a/meta/configs/powershell.yaml
+++ b/meta/configs/powershell.yaml
@@ -1,2 +1,3 @@
 - link:
-    $HOME/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1: windows/powershell/profile.ps1
+    ~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1: windows/powershell/profile.ps1
+    ~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1: windows/powershell/profile.ps1

--- a/windows/powershell/profile.ps1
+++ b/windows/powershell/profile.ps1
@@ -1,6 +1,5 @@
 # Import modules
 Import-Module posh-git
-Import-Module oh-my-posh
 Import-Module PSReadLine
 
 # Autocomplete
@@ -13,4 +12,6 @@ Set-PSReadLineOption -ShowToolTips
 Set-PSReadLineOption -HistoryNoDuplicates
 
 # Set Oh My Posh prompt
-Set-PoshPrompt -Theme ~/adisakshya.yaml
+if (Get-Command oh-my-posh -ErrorAction SilentlyContinue) {
+    oh-my-posh init pwsh --config "$HOME\adisakshya.yaml" | Invoke-Expression
+}


### PR DESCRIPTION
## Summary

Fixes #9 — the PowerShell profile was using the legacy Oh My Posh module API (`Import-Module oh-my-posh` / `Set-PoshPrompt`) which was removed in Oh My Posh v3+ (2021), and only linked the Windows PowerShell 5.x profile path.

### Changes

**`windows/powershell/profile.ps1`**
- Remove `Import-Module oh-my-posh` (the module no longer exists in current installs)
- Replace `Set-PoshPrompt -Theme ~/adisakshya.yaml` with the current binary init:
  ```powershell
  oh-my-posh init pwsh --config "$HOME\adisakshya.yaml" | Invoke-Expression
  ```
- Wrap the init in a `Get-Command oh-my-posh -ErrorAction SilentlyContinue` guard so the profile loads gracefully on machines where oh-my-posh is not installed
- The theme path (`$HOME\adisakshya.yaml`) matches the existing dotbot symlink defined in `meta/configs/oh-my-posh.yaml`

**`meta/configs/powershell.yaml`**
- Add the PowerShell 7+ profile path (`~/Documents/PowerShell/Microsoft.PowerShell_profile.ps1`) alongside the existing Windows PowerShell 5.x path (`~/Documents/WindowsPowerShell/Microsoft.PowerShell_profile.ps1`)
- Both paths symlink to the same `windows/powershell/profile.ps1` source file

## Test plan

- [ ] Run dotbot with `meta/configs/powershell.yaml` — both symlinks should be created
- [ ] Open Windows PowerShell 5.x (`powershell.exe`) — prompt loads without errors
- [ ] Open PowerShell 7+ (`pwsh.exe`) — prompt loads without errors and oh-my-posh theme renders
- [ ] On a machine without oh-my-posh installed, confirm the profile loads without throwing a module-not-found error


---
_Generated by [Claude Code](https://claude.ai/code/session_01RF2UoiRKcQiHhVpF1GDSBV)_