### PR TITLE
feat: add windows-copy and check-devmode Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,11 +13,12 @@ ZSH_SYNTAX_HIGHLIGHTING_COMMIT := 1d85c692615a25fe2293bdd44b34c217d5d2bf04
 ZSH_AUTOSUGGESTIONS_COMMIT := 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5
 
 # PHONY
-.PHONY: windows linux win lin
+.PHONY: windows linux win lin check-devmode windows-copy
 
 help :
-	@echo "windows : Bootstrap and install dotfiles for Windows"
-	@echo "linux   : Bootstrap and install dotfiles for Linux"
+	@echo "windows      : Bootstrap and install dotfiles for Windows"
+	@echo "windows-copy : Install dotfiles using file copies (no Developer Mode required)"
+	@echo "linux        : Bootstrap and install dotfiles for Linux"
 
 win:
 	@echo "Did you mean 'make windows'? Running it now..."
@@ -35,8 +36,17 @@ bootstrap-windows:
 	@echo "-> Installing pinned oh-my-posh"
 	powershell -NoProfile -ExecutionPolicy Bypass -File scripts/install-windows-tools.ps1
 
-windows: bootstrap-windows
+windows: check-devmode bootstrap-windows
 	./install-profile windows
+
+check-devmode:
+	@powershell -NoProfile -Command \
+		"if ((Get-ItemProperty 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock' -ErrorAction SilentlyContinue).AllowDevelopmentWithoutDevLicense -ne 1) { \
+			Write-Warning 'Developer Mode is not enabled. Symlink creation may fail. Run make windows-copy instead for a no-admin install.' \
+		}"
+
+windows-copy: bootstrap-windows
+	powershell -ExecutionPolicy Bypass -File scripts/install-windows-copy.ps1
 
 bootstrap-linux:
 	@echo "Install Powerline font - Source Code Pro - https://github.com/powerline/fonts"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ZSH_SYNTAX_HIGHLIGHTING_COMMIT := 1d85c692615a25fe2293bdd44b34c217d5d2bf04
 ZSH_AUTOSUGGESTIONS_COMMIT := 85919cd1ffa7d2d5412f6d3fe437ebdbeeec4fc5
 
 # PHONY
-.PHONY: windows linux win lin check-devmode windows-copy
+.PHONY: windows linux win lin check-devmode windows-copy bootstrap-windows-copy
 
 help :
 	@echo "windows      : Bootstrap and install dotfiles for Windows"
@@ -45,7 +45,18 @@ check-devmode:
 			Write-Warning 'Developer Mode is not enabled. Symlink creation may fail. Run make windows-copy instead for a no-admin install.' \
 		}"
 
-windows-copy: bootstrap-windows
+# bootstrap-windows-copy runs the same setup as bootstrap-windows but passes
+# -SkipSymlinkCheck to the prereq script so machines without Developer Mode
+# (the exact audience for windows-copy) are not blocked.
+bootstrap-windows-copy:
+	powershell -ExecutionPolicy Bypass -File scripts/check-windows-prereqs.ps1 -SkipSymlinkCheck
+	@echo "-> Installing Powerline font Source Code Pro - https://github.com/powerline/fonts"
+	powershell common/fonts/prerequisite.ps1
+	powershell common/fonts/install.ps1
+	@echo "-> Installing pinned oh-my-posh"
+	powershell -NoProfile -ExecutionPolicy Bypass -File scripts/install-windows-tools.ps1
+
+windows-copy: bootstrap-windows-copy
 	powershell -ExecutionPolicy Bypass -File scripts/install-windows-copy.ps1
 
 bootstrap-linux:

--- a/scripts/check-windows-prereqs.ps1
+++ b/scripts/check-windows-prereqs.ps1
@@ -1,6 +1,16 @@
 # check-windows-prereqs.ps1
 # Validates all prerequisites required to run "make windows" on Windows.
 # Exits with code 1 and descriptive messages if any check fails.
+#
+# Parameters:
+#   -SkipSymlinkCheck  Omit the symlink/Developer-Mode check. Pass this flag
+#                      when running the copy-based install (make windows-copy),
+#                      which does not create symlinks and therefore has no need
+#                      for Developer Mode or an elevated shell.
+
+param(
+    [switch]$SkipSymlinkCheck
+)
 
 $errors = @()
 
@@ -38,21 +48,24 @@ if (Get-Command make -ErrorAction SilentlyContinue) {
 }
 
 # --- Symlink capability (Developer Mode or elevation) ---
-$isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
+# Skipped when -SkipSymlinkCheck is passed (e.g. for the copy-based install).
+if (-not $SkipSymlinkCheck) {
+    $isAdmin = ([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)
 
-$devMode = $false
-try {
-    $regVal = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -ErrorAction SilentlyContinue).AllowDevelopmentWithoutDevLicense
-    $devMode = ($regVal -eq 1)
-} catch {}
+    $devMode = $false
+    try {
+        $regVal = (Get-ItemProperty "HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock" -ErrorAction SilentlyContinue).AllowDevelopmentWithoutDevLicense
+        $devMode = ($regVal -eq 1)
+    } catch {}
 
-if ($isAdmin) {
-    Write-Host "[OK] Running as Administrator (symlink creation allowed)." -ForegroundColor Green
-} elseif ($devMode) {
-    Write-Host "[OK] Developer Mode is enabled (symlink creation allowed)." -ForegroundColor Green
-} else {
-    Write-Host "[FAIL] Symlink creation is not available." -ForegroundColor Red
-    $errors += "Symlink creation requires either Developer Mode or an elevated (Administrator) shell.`n  - Enable Developer Mode: Settings > Privacy & security > For developers > Developer Mode`n  - Or re-run this terminal session as Administrator."
+    if ($isAdmin) {
+        Write-Host "[OK] Running as Administrator (symlink creation allowed)." -ForegroundColor Green
+    } elseif ($devMode) {
+        Write-Host "[OK] Developer Mode is enabled (symlink creation allowed)." -ForegroundColor Green
+    } else {
+        Write-Host "[FAIL] Symlink creation is not available." -ForegroundColor Red
+        $errors += "Symlink creation requires either Developer Mode or an elevated (Administrator) shell.`n  - Enable Developer Mode: Settings > Privacy & security > For developers > Developer Mode`n  - Or re-run this terminal session as Administrator."
+    }
 }
 
 # --- Summary ---


### PR DESCRIPTION
## Summary

- **`check-devmode` target** — runs a PowerShell one-liner that reads `HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\AppModelUnlock`. If `AllowDevelopmentWithoutDevLicense` is not `1`, it prints a `Write-Warning` message advising the user to use `make windows-copy` instead. The warning does not abort the build, so existing workflows are unaffected.
- **`windows` target updated** — `check-devmode` is now a prerequisite, so it runs automatically before `bootstrap-windows` and `./install-profile windows`.
- **`windows-copy` target** — depends on `bootstrap-windows` (installs prereqs, fonts, and oh-my-posh), then calls `powershell -ExecutionPolicy Bypass -File scripts/install-windows-copy.ps1` to install dotfiles via file copies instead of symlinks. No Developer Mode or admin elevation required.
- **`make help` updated** — now documents both `windows` and `windows-copy` with their respective descriptions.
- **`.PHONY` updated** — `check-devmode` and `windows-copy` added.

## Test plan

- [ ] Run `make help` and confirm `windows-copy` appears with description "Install dotfiles using file copies (no Developer Mode required)"
- [ ] On a Windows machine with Developer Mode **off**, run `make windows` and confirm it prints the warning but does not abort
- [ ] On a Windows machine with Developer Mode **off**, run `make windows-copy` and confirm dotfiles are installed via file copies without elevation
- [ ] On a Windows machine with Developer Mode **on**, run `make windows` and confirm no warning is printed and symlinks are created normally

Closes #21