### PR TITLE
Harden the minimal Codespaces dotfiles profile (#45)

### DIFF
--- a/.aliases
+++ b/.aliases
@@ -29,9 +29,6 @@ alias httpserve='python -m http.server'
 # Weather
 alias weather='curl wttr.in'
 
-# Remote playground
-alias playground='python -m webbrowser -t "https://colab.research.google.com/github/adisakshya/playground/blob/master/remote/playground.ipynb"'
-
 # Google Docs
 alias doc='python -m webbrowser -t "https://doc.new"'
 
@@ -52,9 +49,3 @@ alias jn='py -m notebook'
 
 # Extract .tar.gz
 alias extract='tar -xvzf'
-
-# Expose port using localtunnel
-alias expose='function expose_port(){ nohup lt --port &1 > logs/$2.out 2> logs/$2.err & };expose_port && cat $2.out'
-
-# Remote installer
-alias ins='function install(){ make $@ -C ~/.dotfiles/remote; };install'

--- a/.exports
+++ b/.exports
@@ -1,9 +1,3 @@
-# set USER
-export USER="$(whoami)";
-
-# Set bash as shell
-shell="$(which bash)";
-
-# Language preference
-export LANG="en_US.UTF-8";
-export LC_ALL="en_US.UTF-8";
+# Shared environment exports belong here. Do not replace identity variables or
+# force a locale: Codespaces and other containers provide environment-specific
+# values, and a locale must not be selected unless it is installed.

--- a/.github/workflows/install-integration.yml
+++ b/.github/workflows/install-integration.yml
@@ -90,9 +90,18 @@ jobs:
           check "$HOME/.bash_profile"                   "$repo/common/bash/.bash_profile"
           check "$HOME/.aliases"                        "$repo/.aliases"
           check "$HOME/.exports"                        "$repo/.exports"
-          check "$HOME/adisakshya.yaml"                 "$repo/common/oh-my-posh/adisakshya.yaml"
-          check "$HOME/.config/Code/User/settings.json" "$repo/common/vscode/settings.json"
-          check "$HOME/.zshrc"                          "$repo/linux/zsh/.zshrc"
+          check_absent() {
+            local path="$1"
+            if [ -e "$path" ] || [ -L "$path" ]; then
+              echo "FAIL: $path should not be created by the minimal Codespaces profile"
+              fail=1
+              return
+            fi
+            echo "OK:   $path is absent"
+          }
+          check_absent "$HOME/adisakshya.yaml"
+          check_absent "$HOME/.config/Code/User/settings.json"
+          check_absent "$HOME/.zshrc"
           exit $fail
 
   install-windows:

--- a/README.md
+++ b/README.md
@@ -201,13 +201,17 @@ The `install.sh` entrypoint runs Dotbot with the `codespaces` profile (`meta/pro
 |---|---|
 | `bash` | `~/.bashrc` and `~/.bash_profile` |
 | `essentials` | `~/.aliases` and `~/.exports` |
-| `oh-my-posh` | `~/adisakshya.yaml` (prompt theme) |
-| `vscode` | VS Code / Code Server `settings.json` |
-| `zsh` | `~/.zshrc` |
 
-Windows-only configs (`powershell`, `windows-terminal`) and font files are intentionally excluded — they have no effect in a Linux container.
+The profile is intentionally minimal. It does not install or configure Zsh,
+Oh My Zsh, Oh My Posh, fonts, editor settings, language runtimes, databases,
+ports, or services. Those dependencies and settings remain owned by each
+repository's dev container. Existing Bash and essentials files are backed up
+using the [documented policy](#existing-files-and-dry-runs) before they are
+replaced.
 
-> **Note:** `install.sh` creates the config symlinks but does not install `oh-my-posh` or `oh-my-zsh`. If you want the full prompt experience inside a Codespace, add a [devcontainer feature](https://containers.dev/features) or a `postCreateCommand` in your project's `devcontainer.json` to install those tools, or run `make linux` from the dotfiles directory after the Codespace starts.
+`install.sh` is non-interactive and safe to rerun. Shell startup checks for
+optional tools such as NVM and Oh My Posh before initializing them, so tools
+provided by a project can integrate without being required by this profile.
 
 ### Rebuilding after updating dotfiles
 
@@ -218,11 +222,6 @@ cd ~/.dotfiles && git pull && ./install.sh
 ```
 
 Or use **Codespaces → Rebuild container** from the VS Code command palette to get a completely fresh environment.
-
-### Known limitations
-
-- **Fonts** — Powerline / Source Code Pro fonts cannot be installed inside the container. In the browser-based editor, any configured Nerd Font will fall back to the browser's default monospace font. When connecting via a local VS Code client, configure the font in your *local* VS Code settings instead.
-- **oh-my-posh / oh-my-zsh** — `install.sh` creates the config symlinks but does not install these tools. Without them the `~/.zshrc` prompt line will produce an error on first launch; bash is unaffected.
 
 ## Contents
 

--- a/common/bash/.bashrc
+++ b/common/bash/.bashrc
@@ -55,9 +55,11 @@ if command -v oh-my-posh >/dev/null 2>&1; then
     eval "$(oh-my-posh init bash --config "$HOME/adisakshya.yaml")"
 fi
 
-# Disable highlighting
-LS_COLORS=$LS_COLORS:'ow=1;34:' ; export LS_COLORS
+# Disable highlighting for other-writable directories. Preserve an empty or
+# unset LS_COLORS value on minimal container images.
+LS_COLORS="${LS_COLORS:-}:ow=1;34:"
+export LS_COLORS
 
-# Install Ruby Gems to ~/gems'
-export GEM_HOME="${HOME}/gems" >> ~/.bashrc
-export PATH="${HOME}/gems/bin:${PATH}" >> ~/.bashrc
+# Install Ruby Gems to ~/gems.
+export GEM_HOME="${HOME}/gems"
+export PATH="${GEM_HOME}/bin:${PATH}"

--- a/install.sh
+++ b/install.sh
@@ -3,27 +3,15 @@
 # Codespaces looks for install.sh, bootstrap.sh, setup.sh, or script/setup at
 # the repository root and runs the first one it finds.
 #
-# This script is also safe to run on any Linux machine.  For a full local
-# bootstrap that also installs oh-my-posh, oh-my-zsh, and fonts, run
-# `make linux` instead.
+# This script is also safe to run on any Linux machine. It intentionally
+# installs configuration only: project runtimes and optional shell tools are
+# owned by each repository's dev container.
 
 set -euo pipefail
 
 DOTFILES_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 echo "==> Setting up dotfiles..."
-
-# ------------------------------------------------------------------
-# zsh
-# Codespaces base images ship with zsh, so skip installation when it
-# is already present to avoid an unnecessary sudo apt-get call.
-# ------------------------------------------------------------------
-if command -v zsh >/dev/null 2>&1; then
-    echo "    zsh already installed, skipping."
-else
-    echo "    Installing zsh..."
-    "$DOTFILES_DIR/scripts/install-zsh.sh"
-fi
 
 # ------------------------------------------------------------------
 # Dotbot profile
@@ -34,6 +22,7 @@ echo "==> Running Dotbot with the 'codespaces' profile..."
 (cd "$DOTFILES_DIR" && ./install-profile codespaces)
 
 echo "==> Dotfiles setup complete."
+echo "    Installed Bash and shared aliases/exports; optional tools were not installed."
 if [[ "${CODESPACES:-}" == "true" ]]; then
     echo "    Reload your shell or open a new terminal to apply changes."
 fi

--- a/meta/profiles/codespaces
+++ b/meta/profiles/codespaces
@@ -1,5 +1,2 @@
 bash
 essentials
-oh-my-posh
-vscode
-zsh

--- a/remote/Makefile
+++ b/remote/Makefile
@@ -4,7 +4,6 @@
 # Pinned upstream versions. See ../README.md before updating.
 NPM_VERSION := 12.0.1
 GTOP_VERSION := 1.1.5
-LOCALTUNNEL_VERSION := 2.0.2
 CODE_SERVER_VERSION := 4.130.0
 EXTENSION_PACK_VERSION := 1.0.0
 EXTENSION_PACK_SHA256 := 40711c68fe626c202a2fc98f9916ec7e7c0db9d6538394d87d06d7a110d60615
@@ -29,7 +28,6 @@ bootstrap:
 	@echo "--> Installing pinned NPM utilities (registry integrity is verified by npm)"
 	npm install -g npm@$(NPM_VERSION)
 	npm install -g gtop@$(GTOP_VERSION)
-	npm install -g localtunnel@$(LOCALTUNNEL_VERSION)
 	@echo "-> Bootstrap Complete"
 
 install-ngrok:

--- a/tests/codespaces-profile.sh
+++ b/tests/codespaces-profile.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TEST_HOME="$(mktemp -d)"
+trap 'rm -rf "$TEST_HOME"' EXIT
+
+expected_profile=$'bash\nessentials'
+[[ $(cat "$ROOT/meta/profiles/codespaces") == "$expected_profile" ]]
+
+printf 'original bashrc\n' > "$TEST_HOME/.bashrc"
+
+run_install() {
+    HOME="$TEST_HOME" CODESPACES=true "$ROOT/install.sh"
+}
+
+first_output="$(run_install)"
+[[ $first_output == *"Installed Bash and shared aliases/exports"* ]]
+[[ -L $TEST_HOME/.bashrc && -L $TEST_HOME/.bash_profile ]]
+[[ -L $TEST_HOME/.aliases && -L $TEST_HOME/.exports ]]
+[[ ! -e $TEST_HOME/.zshrc && ! -e $TEST_HOME/adisakshya.yaml ]]
+[[ $(find "$TEST_HOME/.dotfiles-backups" -type f -name .bashrc -exec cat {} \;) == "original bashrc" ]]
+
+# An immediate rerun must succeed without creating another backup.
+backup_count="$(find "$TEST_HOME/.dotfiles-backups" -type f | wc -l)"
+run_install >/dev/null
+[[ $(find "$TEST_HOME/.dotfiles-backups" -type f | wc -l) -eq $backup_count ]]
+
+# A minimal interactive Bash must start cleanly without NVM or Oh My Posh.
+shell_output="$(HOME="$TEST_HOME" PS1='$ ' bash --noprofile --rcfile "$TEST_HOME/.bashrc" -i -c 'printf shell-ok' 2>&1)"
+[[ $shell_output == *shell-ok* ]]
+[[ $shell_output != *"command not found"* ]]
+
+echo "codespaces profile tests passed"


### PR DESCRIPTION
### Motivation

- Make the Codespaces profile safe, minimal, and idempotent so dotfiles can be auto-installed in every new Codespace without configuring missing optional tools. 
- Prevent shell startup failures by avoiding implicit runtime/tool installation and by not overriding container-provided identity or locale values.
- Remove obsolete remote assumptions (Playground/Colab/Localtunnel) and ensure documentation matches behavior.

### Description

- Reduce `meta/profiles/codespaces` to only `bash` and `essentials` so Zsh, Oh My Posh, and VS Code settings are not configured by default. 
- Make `install.sh` a non-interactive, configuration-only entrypoint that runs `./install-profile codespaces` and logs that optional tools were not installed. 
- Harden Bash startup in `common/bash/.bashrc` by safely handling `LS_COLORS`, initializing optional tools only when present, and removing the erroneous `>> ~/.bashrc` redirections for Ruby gem paths. 
- Stop overriding identity/locale in `.exports` and remove obsolete `playground`, `expose` (localtunnel) and `ins` aliases from `.aliases`, and drop the unused Localtunnel bootstrap line from `remote/Makefile`. 
- Update `README.md` to document the minimal Codespaces profile, backup/idempotency policy, and that optional tools remain repository/devcontainer-owned. 
- Add an automated end-to-end test `tests/codespaces-profile.sh` that verifies backup creation, symlink creation, immediate rerun idempotency, exclusion of optional configs, and clean Bash startup without missing-tool errors.

### Testing

- Ran `bash -n install.sh common/bash/.bashrc tests/*.sh` for syntax checks and found no issues. (success)
- Executed all repository tests: `tests/backup-dotfiles.sh`, `tests/download-verified.sh`, `tests/pinned-installers.sh`, and the new `tests/codespaces-profile.sh`, and all tests passed. (success)
- Ran `git diff --check` and a repository scan for obsolete `colab`/`playground`/`localtunnel` references (excluding `meta/dotbot`) with no blocking findings. (success)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f121efe208321b643b539052187ff)