### PR TITLE
Complete focused Codespaces release validation for #48

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,6 +42,13 @@ jobs:
           python -c "import yaml; yaml.safe_load(open('meta/base.yaml'))"
           python -c "import yaml; yaml.safe_load(open('meta/force-links-after-backup.yaml'))"
 
+  json-syntax:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate repository-owned JSON
+        run: python -m json.tool windows/windows-terminal/settings.json >/dev/null
+
   makefile-syntax:
     runs-on: ubuntu-latest
     steps:

--- a/README.md
+++ b/README.md
@@ -212,6 +212,23 @@ replaced.
 optional tools such as NVM and Oh My Posh before initializing them, so tools
 provided by a project can integrate without being required by this profile.
 
+### Manual blank-Codespace release check
+
+Before releasing installer or profile changes, create a blank Codespace with
+dotfiles enabled and confirm that:
+
+1. creation completes without a dotfiles installation error;
+2. `~/.bashrc`, `~/.bash_profile`, `~/.aliases`, and `~/.exports` are symlinks
+   into this repository;
+3. `./install.sh` succeeds again from the cloned dotfiles directory; and
+4. a new interactive Bash terminal opens without startup errors, including
+   when optional tools such as NVM and Oh My Posh are absent.
+
+The automated checks validate only this repository's installer, managed files,
+and shell behavior. They do not validate GitHub's Codespaces provisioning,
+browser connectivity, network routing, or the complete hosted service; the
+blank-Codespace check remains the final release verification.
+
 ### VS Code ownership model
 
 VS Code customization uses three deliberately separate layers:


### PR DESCRIPTION
### Motivation

- Reconcile #48 acceptance criteria with the current coverage on `master` and implement only the remaining repository-owned validation gaps. 
- Ensure repository-owned JSON is strictly validated and add a concise manual blank-Codespace release checklist so releases have a final human verification step. 
- Keep the CI boundary explicit: validate only dotfiles installer behavior and shell startup, not GitHub Codespaces provisioning or external network/service behavior.

### Description

- Added a `json-syntax` job to `.github/workflows/validate.yml` that runs `python -m json.tool windows/windows-terminal/settings.json` to enforce strict JSON for the repository-owned Windows Terminal config. 
- Added a `Manual blank-Codespace release check` section to `README.md` documenting the small checklist to perform a final blank-Codespace verification (install, managed symlinks, rerun `./install.sh`, interactive Bash startup with optional tools absent) and restating the CI validation boundary. 
- Intentionally do not treat the historical JSON-with-comments migration file as strict JSON to avoid false positives, and do not add restrictive path filters to existing workflows.

### Testing

- `python -m json.tool windows/windows-terminal/settings.json` — succeeded. 
- Ran all repository smoke tests with `for test in tests/*.sh; do bash "$test"; done` — all tests passed. 
- `git diff --check` — no whitespace or diff-check issues reported. 
- Local YAML validation via `yaml.safe_load(...)` could not be completed in this environment due to a missing `pyyaml` module (`ModuleNotFoundError`); the repository CI job (`dotbot-syntax`) installs and runs the required tooling and will validate Dotbot YAMLs and other checks in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f38259a388321abf5952dd020a0d8)