### PR TITLE
Finish legacy remote tooling cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,19 @@ To remove managed symlinks, manually delete the symlinks listed in the YAML file
 
 After removing symlinks, restore the original files from the `~/.dotfiles-backups/` directory created during installation.
 
+## Optional local Linux tooling
+
+`remote/Makefile` is retained as an opt-in collection of installers for a local
+Debian or Ubuntu environment. Run its advertised targets explicitly with
+`make -C remote <target>`; it is not part of any Dotfiles profile or automatic
+bootstrap path. In particular, GitHub Codespaces and Google Colab do not use
+this Makefile. GitHub provides and operates the Codespaces editor and remote
+service, while this repository only personalises the shell and CLI there.
+
+The `neo4j` recipe is a nonfunctional legacy placeholder. It is intentionally
+not advertised by `make -C remote help`; replacing or removing it belongs in a
+separate, focused cleanup.
+
 ## GitHub Codespaces
 
 GitHub Codespaces supports automatic dotfiles personalisation: when you create a new Codespace, GitHub clones your dotfiles repository and runs the first recognised entrypoint it finds (`install.sh`, `bootstrap.sh`, `setup.sh`, or `script/setup`).

--- a/remote/Makefile
+++ b/remote/Makefile
@@ -1,3 +1,9 @@
+# Optional installers for a local Debian/Ubuntu Linux environment.
+#
+# This Makefile is not used by GitHub Codespaces or Google Colab. GitHub owns
+# the Codespaces editor and remote service; the repository's Codespaces entry
+# point only installs the shell/CLI profile documented in ../README.md.
+
 # Default target
 .DEFAULT_GOAL := help
 
@@ -7,30 +13,22 @@ GTOP_VERSION := 1.1.5
 DOCKER_GPG_SHA256 := 1500c1f56fa9e26b9b8f42452a553675796ade0807cdce11975eb98170b3a570
 DOWNLOAD_VERIFIED := ../scripts/download-verified
 
-.PHONY: bootstrap jekyll docker neo4j install-ngrok
+.PHONY: help bootstrap jekyll docker neo4j
 
 help :
 	@echo "bootstrap     : Bootstrap Environment"
-	@echo "install-ngrok : Install ngrok v3"
 	@echo "jekyll        : Install Jekyll"
 	@echo "docker        : Install Docker"
-	@echo "neo4j         : Install Neo4j"
 
 bootstrap:
 	@echo "-> Bootstraping Environment"
 	sudo apt update
 	@echo "--> Installing required tools and utilities"
-	sudo apt install build-essential httpie nano software-properties-common ca-certificates gnupg lsb-release openssh-server
+	sudo apt install build-essential httpie nano software-properties-common ca-certificates gnupg lsb-release
 	@echo "--> Installing pinned NPM utilities (registry integrity is verified by npm)"
 	npm install -g npm@$(NPM_VERSION)
 	npm install -g gtop@$(GTOP_VERSION)
 	@echo "-> Bootstrap Complete"
-
-install-ngrok:
-	@command -v ngrok >/dev/null 2>&1 && echo "ngrok already installed, skipping." && exit 0; \
-	curl -fsSL https://ngrok-agent.s3.amazonaws.com/ngrok.asc | sudo tee /etc/apt/trusted.gpg.d/ngrok.asc >/dev/null && \
-	echo "deb https://ngrok-agent.s3.amazonaws.com buster main" | sudo tee /etc/apt/sources.list.d/ngrok.list && \
-	sudo apt-get update && sudo apt-get install -y ngrok
 
 jekyll:
 	@command -v jekyll >/dev/null 2>&1 && echo "jekyll already installed, skipping." && exit 0; \
@@ -51,6 +49,8 @@ docker:
 	sudo apt-get update && \
 	sudo apt-get install -y docker-ce docker-ce-cli containerd.io docker-compose-plugin
 
+# Unsupported legacy placeholder: intentionally omitted from `make help`.
+# It remains temporarily to avoid expanding this cleanup into a Neo4j redesign.
 neo4j:
 	@echo "-> Installing Neo4j"
 	@echo "-> Neo4j installtion complete"

--- a/tests/remote-tooling.sh
+++ b/tests/remote-tooling.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REMOTE_MAKEFILE="$ROOT/remote/Makefile"
+
+# Retired remote-access and browser-IDE installers must not return to the local
+# optional tooling collection.
+! grep -qiE 'openssh-server|ngrok|localtunnel|code-server' "$REMOTE_MAKEFILE"
+
+# The public help output is an explicit allowlist. The unsupported Neo4j
+# placeholder remains unadvertised until its future cleanup is scoped.
+expected_help=$'bootstrap     : Bootstrap Environment\njekyll        : Install Jekyll\ndocker        : Install Docker'
+[[ $(make --no-print-directory -C "$ROOT/remote" help) == "$expected_help" ]]
+
+# Do not restore global shortcuts for the retired Playground/Colab workflow or
+# the overly broad installer alias.
+! grep -qE '^[[:space:]]*alias[[:space:]]+(playground|expose|ins)=' "$ROOT/.aliases"
+
+echo "remote tooling checks passed"


### PR DESCRIPTION
### Motivation

- Continue the Issue #46 cleanup by reconciling the remaining remote/Makefile scope against current `master` and the already-merged PRs that removed other retired tooling. 
- Prevent SSH/ngrok/Localtunnel/code-server and retired aliases from being reintroduced into the optional local tooling surface. 

### Description

- Removed `openssh-server` from the `remote/Makefile` `bootstrap` apt install list and removed the `install-ngrok` target and its help/phony entry, and updated the `.PHONY` listing and `help` output accordingly. 
- Added an explanatory header in `remote/Makefile` and a new README paragraph documenting that `remote/Makefile` is an opt-in collection of installers for local Debian/Ubuntu environments and is not used by GitHub Codespaces or Colab. 
- Marked the `neo4j` recipe as an unsupported legacy placeholder and excluded it from the public `make -C remote help` output to avoid scope creep. 
- Added `tests/remote-tooling.sh`, a focused regression check that ensures retired surfaces (`openssh-server`, `ngrok`, `localtunnel`, `code-server`) and retired aliases (`playground`, `expose`, `ins`) do not reappear and that `remote/Makefile` advertises only the supported targets. 

### Testing

- Ran `make --dry-run help` and `make --no-print-directory -C remote help`, both succeeded and reflect the updated allowlist of advertised targets. 
- Executed the repository test suite with `for test in tests/*.sh; do bash "$test"; done`, and all tests passed (including `tests/backup-dotfiles.sh`, `tests/codespaces-profile.sh`, `tests/download-verified.sh`, `tests/pinned-installers.sh`, `tests/vscode-strategy.sh`, and the new `tests/remote-tooling.sh`). 
- Validated YAML and JSON with Python (`yaml.safe_load` and `python3 -m json.tool`) and ran ShellCheck where available; static validations completed successfully (ShellCheck was installed in the environment for the run). 
- Performed a repo-wide search for stale references to the retired tooling and confirmed remaining matches are limited to intentional negative regression checks and the legitimate Codespaces ownership statement.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6f3a5fbb5c832190add19bd192b3e1)